### PR TITLE
Add the -v flag for verbose output with `go test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: dependencies test
 
 test:
-	go test ./...
+	go test -v ./...
 
 dependencies:
 	which go


### PR DESCRIPTION
Example output below

```
[djworth@Dans-MacBook-Pro go-seed (test_verbose)]$ make
which go
/Users/djworth/tools/go/bin/go
go test -v ./...
=== RUN Test_Greet
--- PASS: Test_Greet (0.00 seconds)
PASS
ok      _/Users/djworth/projects/go-seed    0.005s
```
